### PR TITLE
mem_space: support accesses with an offset

### DIFF
--- a/include/arch/aarch64/mem_space.hpp
+++ b/include/arch/aarch64/mem_space.hpp
@@ -210,6 +210,34 @@ namespace _detail {
 			return static_cast<typename RT::rep_type>(b);
 		}
 
+		template<typename RT>
+		void store(RT r, ptrdiff_t offset, typename RT::rep_type value) const {
+			auto p = reinterpret_cast<typename RT::bits_type *>(_base + r.offset() + offset);
+			auto v = static_cast<typename RT::bits_type>(value);
+			mem_ops<typename RT::bits_type>::store(p, v);
+		}
+
+		template<typename RT>
+		typename RT::rep_type load(RT r, ptrdiff_t offset) const {
+			auto p = reinterpret_cast<const typename RT::bits_type *>(_base + r.offset() + offset);
+			auto b = mem_ops<typename RT::bits_type>::load(p);
+			return static_cast<typename RT::rep_type>(b);
+		}
+
+		template<typename RT>
+		void store_relaxed(RT r, ptrdiff_t offset, typename RT::rep_type value) const {
+			auto p = reinterpret_cast<typename RT::bits_type *>(_base + r.offset() + offset);
+			auto v = static_cast<typename RT::bits_type>(value);
+			mem_ops<typename RT::bits_type>::store_relaxed(p, v);
+		}
+
+		template<typename RT>
+		typename RT::rep_type load_relaxed(RT r, ptrdiff_t offset) const {
+			auto p = reinterpret_cast<const typename RT::bits_type *>(_base + r.offset() + offset);
+			auto b = mem_ops<typename RT::bits_type>::load_relaxed(p);
+			return static_cast<typename RT::rep_type>(b);
+		}
+
 	private:
 		uintptr_t _base;
 	};

--- a/include/arch/arm/mem_space.hpp
+++ b/include/arch/arm/mem_space.hpp
@@ -151,6 +151,20 @@ namespace _detail {
 			return static_cast<typename RT::rep_type>(b);
 		}
 
+		template<typename RT>
+		void store(RT r, ptrdiff_t offset, typename RT::rep_type value) const {
+			auto p = reinterpret_cast<typename RT::bits_type *>(_base + r.offset() + offset);
+			auto v = static_cast<typename RT::bits_type>(value);
+			mem_ops<typename RT::bits_type>::store(p, v);
+		}
+
+		template<typename RT>
+		typename RT::rep_type load(RT r, ptrdiff_t offset) const {
+			auto p = reinterpret_cast<const typename RT::bits_type *>(_base + r.offset() + offset);
+			auto b = mem_ops<typename RT::bits_type>::load(p);
+			return static_cast<typename RT::rep_type>(b);
+		}
+
 	private:
 		uintptr_t _base;
 	};

--- a/include/arch/riscv64/mem_space.hpp
+++ b/include/arch/riscv64/mem_space.hpp
@@ -115,6 +115,20 @@ namespace _detail {
 			return static_cast<typename RT::rep_type>(b);
 		}
 
+		template<typename RT>
+		void store(RT r, ptrdiff_t offset, typename RT::rep_type value) const {
+			auto p = reinterpret_cast<typename RT::bits_type *>(_base + r.offset() + offset);
+			auto v = static_cast<typename RT::bits_type>(value);
+			mem_ops<typename RT::bits_type>::store(p, v);
+		}
+
+		template<typename RT>
+		typename RT::rep_type load(RT r, ptrdiff_t offset) const {
+			auto p = reinterpret_cast<const typename RT::bits_type *>(_base + r.offset() + offset);
+			auto b = mem_ops<typename RT::bits_type>::load(p);
+			return static_cast<typename RT::rep_type>(b);
+		}
+
 	private:
 		uintptr_t _base;
 	};

--- a/include/arch/x86/mem_space.hpp
+++ b/include/arch/x86/mem_space.hpp
@@ -118,6 +118,20 @@ namespace _detail {
 			return static_cast<typename RT::rep_type>(b);
 		}
 
+		template<typename RT>
+		void store(RT r, ptrdiff_t offset, typename RT::rep_type value) const {
+			auto p = reinterpret_cast<typename RT::bits_type *>(_base + r.offset() + offset);
+			auto v = static_cast<typename RT::bits_type>(value);
+			mem_ops<typename RT::bits_type>::store(p, v);
+		}
+
+		template<typename RT>
+		typename RT::rep_type load(RT r, ptrdiff_t offset) const {
+			auto p = reinterpret_cast<const typename RT::bits_type *>(_base + r.offset() + offset);
+			auto b = mem_ops<typename RT::bits_type>::load(p);
+			return static_cast<typename RT::rep_type>(b);
+		}
+
 	private:
 		uintptr_t _base;
 	};


### PR DESCRIPTION
Add versions of read/write that take in an additional offset. It is useful for accessing register arrays, previously you had to do something like
```cpp
auto value = arch::scalar_load_relaxed<arch::bit_value<uint32_t>>(space, regs::myRegStart + index * 4);
value |= myReg::value(true);
arch::scalar_store_relaxed(space, regArrayStartOffset + index * 4, value);
```

whereas with this change you can do
```cpp
auto value = space.load_relaxed(regs::myReg, index * 4);
value |= myReg::value(true);
space.store_relaxed(regs::myReg, index * 4, value);
```