### PR TITLE
dma_structs: Refactor to use dma_region

### DIFF
--- a/include/arch/dma_pool.hpp
+++ b/include/arch/dma_pool.hpp
@@ -7,9 +7,9 @@
 namespace arch {
 
 static_assert(
-	requires(contiguous_pool *self, size_t size, size_t count, size_t align, void *pointer) {
-		{ self->allocate(size, count, align) } -> std::same_as<void *>;
-		{ self->deallocate(pointer, size, count, align) } -> std::same_as<void>;
+	requires(contiguous_pool *self, size_t size, size_t count, size_t align, dma_ptr ptr) {
+		{ self->allocate(size, count, align) } -> std::same_as<dma_ptr>;
+		{ self->deallocate(ptr, size, count, align) } -> std::same_as<void>;
 	}
 );
 

--- a/include/arch/dma_structs.hpp
+++ b/include/arch/dma_structs.hpp
@@ -4,6 +4,8 @@
 #include <assert.h>
 #include <cstddef>
 #include <new>
+#include <optional>
+#include <stdint.h>
 #include <utility>
 
 namespace arch {
@@ -12,11 +14,102 @@ namespace arch {
 // DMA pool infrastructure.
 // ----------------------------------------------------------------------------
 
+struct dma_pool;
+
+// Memory region suitable for DMA.
+// DMA buffers/objects/arrays are subsets of a dma_region.
+struct dma_region {
+	constexpr dma_region(dma_pool *pool)
+	: pool_{pool} { }
+
+	dma_region(const dma_region &) = delete;
+
+	dma_region &operator= (const dma_region &) = delete;
+
+	dma_pool *pool() const {
+		return pool_;
+	}
+
+	bool has_va() const {
+		return static_cast<bool>(base_va);
+	}
+
+	// Allows DMA objects to access the region (if it is mapped).
+	uintptr_t get_base_va() const {
+		assert(base_va);
+		return *base_va;
+	}
+
+	template<typename T = void>
+	T *get_raw_ptr(size_t offset) const {
+		return reinterpret_cast<T *>(get_base_va() + offset);
+	}
+
+protected:
+	// Virtual address where the region is mapped (if it is mapped).
+	std::optional<uintptr_t> base_va;
+
+private:
+	dma_pool *pool_;
+};
+
+// dma_region that is used if nullptr is passed as dma_pool.
+struct host_dma_region_impl : dma_region {
+	constexpr host_dma_region_impl()
+	: dma_region{nullptr} {
+		base_va = 0;
+	}
+};
+
+inline constinit host_dma_region_impl host_dma_region;
+
+// Fat pointer that points to a single DMA buffer/object/array inside a dma_region.
+struct dma_ptr {
+	dma_ptr() = default;
+
+	dma_ptr(dma_region *region, size_t offset)
+	: _region{region}, _offset{offset} { }
+
+	explicit operator bool () {
+		// Null pointers (i.e., default constructed dma_ptr) are always mapped.
+		return _region->has_va() && !get_raw_ptr();
+	}
+
+	dma_pool *pool() {
+		return _region->pool();
+	}
+
+	dma_region *region() {
+		return _region;
+	}
+
+	size_t offset() {
+		return _offset;
+	}
+
+	template<typename T = void>
+	T *get_raw_ptr() const {
+		return _region->get_raw_ptr<T>(_offset);
+	}
+
+	dma_ptr offset_by(size_t off) const {
+		return {_region, _offset + off};
+	}
+
+private:
+	dma_region *_region{&host_dma_region};
+	size_t _offset{0};
+};
+
+inline dma_ptr make_host_dma_ptr(void *p) {
+	return {&host_dma_region, reinterpret_cast<uintptr_t>(p)};
+}
+
 struct dma_pool {
 	virtual ~dma_pool() = default;
 
-	virtual void *allocate(size_t size, size_t count, size_t align) = 0;
-	virtual void deallocate(void *pointer, size_t size, size_t count, size_t align) = 0;
+	virtual dma_ptr allocate(size_t size, size_t count, size_t align) = 0;
+	virtual void deallocate(dma_ptr ptr, size_t size, size_t count, size_t align) = 0;
 };
 
 // ----------------------------------------------------------------------------
@@ -25,88 +118,88 @@ struct dma_pool {
 
 struct dma_buffer_view {
 	dma_buffer_view()
-	: _pool{nullptr}, _data{nullptr}, _size{0} { }
+	: _size{0} { }
 
-	explicit dma_buffer_view(dma_pool *pool, void *data, size_t size)
-	: _pool{pool}, _data{data}, _size{size} {}
+	explicit dma_buffer_view(dma_ptr ptr, size_t size)
+	: _ptr{ptr}, _size{size} { }
+
+	// For backwards compatibility: previous API took a dma_pool pointer.
+	explicit dma_buffer_view(std::nullptr_t, void *data, size_t size)
+	: _ptr{make_host_dma_ptr(data)}, _size{size} { }
 
 	size_t size() const {
 		return _size;
 	}
 
 	void *data() const {
-		return _data;
+		return _ptr.get_raw_ptr();
 	}
 
 	std::byte *byte_data() {
-		return static_cast<std::byte *>(_data);
+		return static_cast<std::byte *>(data());
 	}
 
 	dma_buffer_view subview(size_t offset, size_t chunk) const {
 		assert(offset <= _size);
 		assert(offset + chunk <= _size);
-		return dma_buffer_view{_pool, (char *)_data + offset, chunk};
+		return dma_buffer_view{_ptr.offset_by(offset), chunk};
 	}
 
 	dma_buffer_view subview(size_t offset) const {
 		assert(offset <= _size);
-		return dma_buffer_view{_pool, (char *)_data + offset, _size - offset};
+		return dma_buffer_view{_ptr.offset_by(offset), _size - offset};
 	}
 
 private:
-	dma_pool *_pool;
-	void *_data;
+	dma_ptr _ptr;
 	size_t _size;
 };
 
 template<typename T>
 struct dma_object_view {
-	dma_object_view()
-	: _pool{nullptr}, _data{nullptr} { }
+	dma_object_view() = default;
 
-	explicit dma_object_view(dma_pool *pool, T *data)
-	: _pool{pool}, _data{data} { }
+	explicit dma_object_view(dma_ptr ptr)
+	: _ptr{ptr} { }
 
 	T *data() const {
-		return _data;
+		return _ptr.get_raw_ptr<T>();
 	}
 
 	T &operator* () const {
-		return *_data;
+		return *data();
 	}
 
 	T *operator-> () const {
-		return _data;
+		return data();
 	}
 
 private:
-	dma_pool *_pool;
-	T *_data;
+	dma_ptr _ptr;
 };
 
 template<typename T>
 struct dma_array_view {
 	dma_array_view()
-	: _pool{nullptr}, _data{nullptr}, _size{0} { }
+	: _size{0} { }
 
-	explicit dma_array_view(dma_pool *pool, T *data, size_t size)
-	: _pool{pool}, _data{data}, _size{size} { }
+	explicit dma_array_view(dma_ptr ptr, size_t size)
+	: _ptr{ptr}, _size{size} { }
 
 	size_t size() const {
 		return _size;
 	}
 
 	T *data() const {
-		return _data;
+		return _ptr.get_raw_ptr<T>();
 	}
 
 	T &operator[] (size_t n) const {
-		return _data[n];
+		return data()[n];
 	}
 
 private:
-	dma_pool *_pool;
-	T *_data;
+	dma_ptr _ptr;
 	size_t _size;
 };
 
@@ -117,13 +210,12 @@ private:
 struct dma_buffer {
 	friend void swap(dma_buffer &a, dma_buffer &b) {
 		using std::swap;
-		swap(a._pool, b._pool);
-		swap(a._data, b._data);
+		swap(a._ptr, b._ptr);
 		swap(a._size, b._size);
 	}
 
 	dma_buffer()
-	: _pool{nullptr}, _data{nullptr}, _size{0} { }
+	: _size{0} { }
 
 	dma_buffer(dma_buffer &&other)
 	: dma_buffer() {
@@ -131,19 +223,22 @@ struct dma_buffer {
 	}
 
 	explicit dma_buffer(dma_pool *pool, size_t size)
-	: _pool{pool}, _size{size} {
-		if(_pool) {
-			_data = _pool->allocate(_size, 1, 1);
+	: _size{size} {
+		if(pool) {
+			_ptr = pool->allocate(_size, 1, 1);
 		}else{
-			_data = operator new(_size);
+			void *p = operator new(_size);
+			_ptr = make_host_dma_ptr(p);
 		}
 	}
 
 	~dma_buffer() {
-		if(_pool) {
-			_pool->deallocate(_data, _size, 1, 1);
+		if (!_ptr)
+			return;
+		if(_ptr.pool()) {
+			_ptr.pool()->deallocate(_ptr, _size, 1, 1);
 		}else{
-			operator delete(_data, _size);
+			operator delete(data(), _size);
 		}
 	}
 
@@ -153,29 +248,27 @@ struct dma_buffer {
 	}
 
 	operator dma_buffer_view () {
-		return dma_buffer_view{_pool, _data, _size};
+		return dma_buffer_view{_ptr, _size};
 	}
 
 	size_t size() {
 		return _size;
 	}
 
-	void *data() {
-		return _data;
+	void *data() const {
+		return _ptr.get_raw_ptr();
 	}
 
 	dma_buffer_view subview(size_t offset, size_t chunk) {
-		return dma_buffer_view{_pool, (char *)_data + offset, chunk};
+		return dma_buffer_view{_ptr.offset_by(offset), chunk};
 	}
 
 	dma_buffer_view subview(size_t offset) {
-		return dma_buffer_view{_pool, (char *)_data + offset,
-			_size - offset};
+		return dma_buffer_view{_ptr.offset_by(offset), _size - offset};
 	}
 
 private:
-	dma_pool *_pool;
-	void *_data;
+	dma_ptr _ptr;
 	size_t _size;
 };
 
@@ -183,12 +276,10 @@ template<typename T>
 struct dma_object {
 	friend void swap(dma_object &a, dma_object &b) {
 		using std::swap;
-		swap(a._pool, b._pool);
-		swap(a._data, b._data);
+		swap(a._ptr, b._ptr);
 	}
 
-	dma_object()
-	: _pool{nullptr}, _data{nullptr} { }
+	dma_object() = default;
 
 	dma_object(dma_object &&other)
 	: dma_object() {
@@ -196,24 +287,24 @@ struct dma_object {
 	}
 
 	template<typename... Args>
-	explicit dma_object(dma_pool *pool, Args &&... args)
-	: _pool{pool} {
-		void *p;
-		if(_pool) {
-			p = _pool->allocate(sizeof(T), 1, alignof(T));
+	explicit dma_object(dma_pool *pool, Args &&... args) {
+		if(pool) {
+			_ptr = pool->allocate(sizeof(T), 1, alignof(T));
 		}else{
-			p = operator new(sizeof(T), std::align_val_t(alignof(T)));
+			auto p = operator new(sizeof(T), std::align_val_t(alignof(T)));
+			_ptr = make_host_dma_ptr(p);
 		}
-		_data = new (p) T{std::forward<Args>(args)...};
+		new (_ptr.get_raw_ptr()) T{std::forward<Args>(args)...};
 	}
 
 	~dma_object() {
-		if(_data)
-			_data->~T();
-		if(_pool) {
-			_pool->deallocate(_data, sizeof(T), 1, alignof(T));
+		if (!_ptr)
+			return;
+		data()->~T();
+		if(_ptr.pool()) {
+			_ptr.pool()->deallocate(_ptr, sizeof(T), 1, alignof(T));
 		}else{
-			operator delete(_data, sizeof(T), std::align_val_t(alignof(T)));
+			operator delete(data(), sizeof(T), std::align_val_t(alignof(T)));
 		}
 	}
 
@@ -223,97 +314,39 @@ struct dma_object {
 	}
 
 	operator dma_object_view<T> () {
-		return dma_object_view<T>{_pool, _data};
+		return dma_object_view<T>{_ptr};
 	}
 
 	T *data() {
-		return _data;
+		return _ptr.get_raw_ptr<T>();
 	}
 
 	T &operator* () {
-		return *_data;
+		return *data();
 	}
 
 	T *operator-> () {
-		return _data;
+		return data();
 	}
 
 	dma_buffer_view view_buffer() {
-		return dma_buffer_view{_pool, _data, sizeof(T)};
+		return dma_buffer_view{_ptr, sizeof(T)};
 	}
 
 private:
-	dma_pool *_pool;
-	T *_data;
-};
-
-// Like dma_object but stores the object on the stack if the class is initialized
-// with a null dma_pool pointer.
-template<typename T>
-struct dma_small_object {
-	dma_small_object()
-	: _pool{nullptr}, _data{nullptr} { }
-
-	template<typename... Args>
-	explicit dma_small_object(dma_pool *pool, Args &&... args)
-	: _pool{pool} {
-		void *p;
-		if(_pool) {
-			p = _pool->allocate(sizeof(T), 1, alignof(T));
-		}else{
-			p = _embedded;
-		}
-		_data = new (p) T{std::forward<Args>(args)...};
-	}
-
-	dma_small_object(const dma_small_object &) = delete;
-
-	~dma_small_object() {
-		if(_data)
-			_data->~T();
-		if(_pool)
-			_pool->deallocate(_data, sizeof(T), 1, alignof(T));
-	}
-
-	dma_small_object &operator= (const dma_small_object &) = delete;
-
-	operator dma_object_view<T> () {
-		return dma_object_view<T>{_pool, _data};
-	}
-
-	T *data() {
-		return _data;
-	}
-
-	T &operator* () {
-		return *_data;
-	}
-
-	T *operator-> () {
-		return _data;
-	}
-
-	dma_buffer_view view_buffer() {
-		return dma_buffer_view{_pool, _data, sizeof(T)};
-	}
-
-private:
-	dma_pool *_pool;
-	T *_data;
-	alignas(alignof(T)) std::byte _embedded[sizeof(T)];
+	dma_ptr _ptr;
 };
 
 template<typename T>
 struct dma_array {
 	friend void swap(dma_array &a, dma_array &b) {
 		using std::swap;
-		swap(a._pool, b._pool);
-		swap(a._data, b._data);
+		swap(a._ptr, b._ptr);
 		swap(a._size, b._size);
 	}
 
 	dma_array()
-	: _pool{nullptr}, _data{nullptr}, _size(0) { }
+	: _size(0) { }
 
 	dma_array(dma_array &&other)
 	: dma_array() {
@@ -321,27 +354,27 @@ struct dma_array {
 	}
 
 	explicit dma_array(dma_pool *pool, size_t size)
-	: _pool{pool}, _size{size} {
-		void *p;
-		if(_pool) {
-			p = _pool->allocate(sizeof(T), _size, alignof(T));
+	: _size{size} {
+		if(pool) {
+			_ptr = pool->allocate(sizeof(T), _size, alignof(T));
 		}else{
 			// TODO: Check for overflow.
-			p = operator new(sizeof(T) * _size, std::align_val_t(alignof(T)));
+			auto p = operator new(sizeof(T) * _size, std::align_val_t(alignof(T)));
+			_ptr = make_host_dma_ptr(p);
 		}
-		_data = new (p) T[_size];
+		new (_ptr.get_raw_ptr()) T[_size];
 	}
 
 	~dma_array() {
-		if(_data) {
-			for(size_t i = 0; i < _size; ++i)
-				_data[i].~T();
-		}
-		if(_pool) {
-			_pool->deallocate(_data, sizeof(T), _size, alignof(T));
+		if (!_ptr)
+			return;
+		for(size_t i = 0; i < _size; ++i)
+			data()[i].~T();
+		if(_ptr.pool()) {
+			_ptr.pool()->deallocate(_ptr, sizeof(T), _size, alignof(T));
 		}else{
 			// TODO: Check for overflow.
-			operator delete(_data, sizeof(T) * _size, std::align_val_t(alignof(T)));
+			operator delete(data(), sizeof(T) * _size, std::align_val_t(alignof(T)));
 		}
 	}
 
@@ -351,7 +384,7 @@ struct dma_array {
 	}
 
 	operator dma_array_view<T> () {
-		return dma_array_view<T>{_pool, _data, _size};
+		return dma_array_view<T>{_ptr, _size};
 	}
 
 	size_t size() {
@@ -359,20 +392,19 @@ struct dma_array {
 	}
 
 	T *data() {
-		return _data;
+		return _ptr.get_raw_ptr<T>();
 	}
 
 	T &operator[] (size_t n) {
-		return _data[n];
+		return data()[n];
 	}
 
 	dma_buffer_view view_buffer() {
-		return dma_buffer_view{_pool, _data, sizeof(T) * _size};
+		return dma_buffer_view{_ptr, sizeof(T) * _size};
 	}
 
 private:
-	dma_pool *_pool;
-	T *_data;
+	dma_ptr _ptr;
 	size_t _size;
 };
 


### PR DESCRIPTION
This PR adds an indirection between the DMA structs and the `dma_pool`. In particular, we let the DMA structs point to a `dma_region` which in turn points to `dma_pool`. The intention is that `dma_region` will store the allocation meta data (such that it does not have to be part of the allocated memory itself).